### PR TITLE
Upgrade e2e tests scaffold

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,49 @@
-FROM balenalib/intel-nuc-node:10.16.3-stretch-build-20190920
+# build
+FROM balenalib/intel-nuc-node:10-stretch-build AS builder
 
-# Install PIP, Robot Framework, Resin-cli and Etcher-cli
-RUN apt-get update && apt-get install -y qemu-system-x86 rsync qemu-kvm minicom libftdi-dev python-pip python-setuptools python-wheel systemd && \
-    rm -rf /var/lib/apt/lists/* && \
-    pip install robotframework==3.0 requests==2.4.3 robotframework-requests==0.4.5 pylibftdi==0.15.0 && \
-    npm install --global balena-cli@10.17.6 && \
-    git clone --depth 1  --branch v1.5.57 https://github.com/resin-io/etcher.git && cd /etcher && \
-    npm install --production && \
-    ln -sf /etcher/bin/etcher /usr/local/bin/etcher
+WORKDIR /opt
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential flex bison rsync minicom libftdi-dev python-pip \
+      python-setuptools python-wheel systemd && \
+      rm -rf /var/lib/apt/lists/*
+
+ENV VIRTUAL_ENV=/opt/venv
+
+RUN pip install virtualenv && python -m virtualenv $VIRTUAL_ENV
+
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY requirements.txt .
+
+# https://github.com/nodejs/node/issues/19348
+RUN pip install -r requirements.txt && \
+      npm install --global balena-cli@10.17.6 && \
+      wget -q https://download.qemu.org/qemu-4.2.0.tar.xz && \
+      echo 'd3481d4108ce211a053ef15be69af1bdd9dde1510fda80d92be0f6c3e98768f0  qemu-4.2.0.tar.xz' | sha256sum -c - && \
+      tar -xf qemu-4.2.0.tar.xz && cd qemu-4.2.0 && ./configure && make && make install
+
+
+# runtime
+FROM balenalib/intel-nuc-node:10-stretch-run
+
+ENV VIRTUAL_ENV=/opt/venv
+
+ENV PATH="$VIRTUAL_ENV/bin:/usr/local/bin:$PATH"
+
+ENV PYTHONHOME=$VIRTUAL_ENV
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git openssh-client rsync minicom systemd \
+      libxml2 libpixman-1-0 libpng16-16 libjpeg62-turbo \
+      libglib2.0-0 libfdt1 zlib1g && \
+      rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/venv /opt/venv
+
+COPY --from=builder /usr/lib/python2.7 /usr/lib/python2.7
+
+COPY --from=builder /usr/local /usr/local
 
 ADD fixtures/ssh_config /root/.ssh/config
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+robotframework==3.0
+requests==2.4.3
+robotframework-requests==0.4.5
+pylibftdi==0.15.0

--- a/resources/resinos.robot
+++ b/resources/resinos.robot
@@ -22,8 +22,8 @@ Mount "${path}" on "${mount_destination}"
 Check host OS fingerprint file in "${image}" on "${partition}" partition
     [Documentation]    Available items for argument ${partition} are: boot, root
     &{dict} =  Create Dictionary    boot=1    root=2
-    ${LOOPDEVICE} =   Set up loop device for "${image}"
-    ${random} =   Evaluate    random.randint(0, sys.maxint)    modules=random, sys
+    ${LOOPDEVICE} =  Set up loop device for "${image}"
+    ${random} =  Evaluate    random.randint(0, sys.maxint)    modules=random, sys
     Set Test Variable    ${mount_destination}    /tmp/${random}
     Run Keyword If    '${partition}' == 'boot'    Set Test Variable    ${fingerprint_file}    ${mount_destination}/resinos.fingerprint
     Create Directory    ${mount_destination}


### PR DESCRIPTION
* bump balena base image version
* add multistage builds
* build QEMU 4.2.0 (dynamic linking)
* refactor Dockerfile
* add Python virtualenv
* remove defunct Etcher cli reference (RPi3.robot)

Change-type: minor
Signed-off-by: ab77 <anton@balena.io>