### PR TITLE
qemu: build qemu-5.2.0 from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build-docker-image: Dockerfile
 test: build-docker-image
 	@echo '[Info] Starting tests inside container...'
 	@docker run -it --rm --name ${DOCKER_IMAGE} \
-		-v /home/horia/sandbox/autohat/:/autohat \
+		-v $(PWD):/autohat \
 		-v /dev/:/dev2 --privileged \
 		--env-file ./env.list \
 		$(DOCKER_IMAGE) \


### PR DESCRIPTION
QEMU 5.2.0 is much faster than v4 and is being rolled out across
other balena projects. In this case we are still building QEMU
from source as we need the system utilities for x86-64 and not
for arm-static emulation.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Depends-on: https://github.com/balena-io/autohat/pull/126