### PR TITLE
update fingerprint path

### DIFF
--- a/resources/resinos.robot
+++ b/resources/resinos.robot
@@ -25,13 +25,17 @@ Check host OS fingerprint file in "${image}" on "${partition}" partition
     ${LOOPDEVICE} =  Wait Until Keyword Succeeds    6x    5s    Set up loop device for "${image}"
     ${random} =  Evaluate    random.randint(0, sys.maxsize)    modules=random, sys
     Set Test Variable    ${mount_destination}    /tmp/${random}
-    Run Keyword If    '${partition}' == 'boot'    Set Test Variable    ${fingerprint_file}    ${mount_destination}/*.fingerprint
     Create Directory    ${mount_destination}
     Mount "${LOOPDEVICE}p${dict.${partition}}" on "${mount_destination}"
+    ${balenaos}= 	Run and Return RC  ls ${mount_destination}/balenaos.fingerprint
+    ${resinos}= 	Run and Return RC  ls ${mount_destination}/resinos.fingerprint
+    Run Keyword If    '${resinos}' == '0' and '${partition}' == 'boot'   Set Global Variable   ${fingerprint_file_name}    resinos.fingerprint
+    Run Keyword If    '${balenaos}' == '0' and '${partition}' == 'boot'  Set Global Variable   ${fingerprint_file_name}    balenaos.fingerprint
+    Run Keyword If    '${partition}' == 'boot'  Set Test Variable   ${fingerprint_file}  ${mount_destination}/${fingerprint_file_name}   
     ${path_to_home_p2} =    Run Keyword If    '${partition}' == 'root'    Run Process    find ${mount_destination} -name "home"    shell=yes
     ${path_to_fingerprint_p2}    ${last} =    Run Keyword If    '${partition}' == 'root'    Split String From Right    ${path_to_home_p2.stdout}    /    1
-    Run Keyword If    '${partition}' == 'root'    Set Test Variable   ${fingerprint_p2_resin-boot}    ${path_to_fingerprint_p2}/resin-boot/*.fingerprint
-    Run Keyword If    '${partition}' == 'root'    Set Test Variable    ${fingerprint_file}    ${path_to_fingerprint_p2}/*.fingerprint
+    Run Keyword If    '${partition}' == 'root'    Set Test Variable   ${fingerprint_p2_resin-boot}    ${path_to_fingerprint_p2}/resin-boot/${fingerprint_file_name} 
+    Run Keyword If    '${partition}' == 'root'    Set Test Variable    ${fingerprint_file}    ${path_to_fingerprint_p2}/${fingerprint_file_name} 
     Run Keyword If    '${partition}' == 'root'    File Should Exist    ${fingerprint_p2_resin-boot}   msg=Couldn't find ${fingerprint_p2_resin-boot}
     ${content_fingerprint_p2_resin-boot} =    Run Keyword If    '${partition}' == 'root'    Get File    ${fingerprint_p2_resin-boot}
     File Should Exist   ${fingerprint_file}     msg=Couldn't find ${fingerprint_file} in ${mount_destination}


### PR DESCRIPTION
updating the tests to account for the renaming of `resinos.fingerprint` to `balenaos.fingerprint` from OS versions >2,72.

E2E tests fail at the moment with more recent OS images because of this: https://www.flowdock.com/app/rulemotion/r-resinos/threads/rRNb1cm3UYhvJ-bqne_aCmCX_kh

This fix makes the test pass for both new and old fingerprint file names. Tested locally with v2.38 and v2.83 of the `qemux86-64` image. 