### PR TITLE
Force public DNS resolution for QEMU guest VMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG ARCH=amd64
 
 FROM balenalib/${ARCH}-node:16-bullseye-build AS cli-build
 
-ARG BALENA_CLI_VERSION=13.1.8
+ARG BALENA_CLI_VERSION=13.1.11
 
 WORKDIR /opt
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The resources directory contains Robot Keyword helpers for ``resincli`` and hard
     ``docker run -it --rm -v <path_to_repo>:/autohat -v /dev/:/dev2 --privileged --env-file ./env.list autohat robot --exitonerror /autohat/raspberrypi3.robot``
 
 ### Troubleshooting
+> Ctrl-A-X to exit QEMU monitor
 
     docker exec -ti {{id-or-name-of-running-autohat-container}} bash
 

--- a/resources/qemu.robot
+++ b/resources/qemu.robot
@@ -20,9 +20,9 @@ Run "${image}" with "${memory}" MB memory "${cpus}" cpus and "${serial_port_path
     Run Keyword And Return If    '${result.stdout}' != '0'    Run image with KVM enabled
 
 Run image with KVM enabled
-    ${handle} =  Start Process    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image_copy},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -net nic,model\=virtio -net \"user,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc,accel\=kvm -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server,nowait -serial chardev:serial0    shell=yes
+    ${handle} =  Start Process    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image_copy},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc,accel\=kvm -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server,nowait -serial chardev:serial0    shell=yes
     Return From Keyword    ${handle}
 
 Run image with KVM disabled
-    ${handle} =  Start Process    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image_copy},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -net nic,model\=virtio -net \"user,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server,nowait -serial chardev:serial0    shell=yes
+    ${handle} =  Start Process    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image_copy},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server,nowait -serial chardev:serial0    shell=yes
     Return From Keyword    ${handle}


### PR DESCRIPTION
* forces QEMU guests to use external DNS directly
  instead of local Docker bridge DNS
* avoids having to use more complicated TAP networking
* See, https://wiki.qemu.org/Documentation/Networking
  https://unix.stackexchange.com/a/614603/78029
  https://stackoverflow.com/a/41747522/1559300

Change-type: minor