### PR TITLE
Configures the test image with a custom DNS server.

### DIFF
--- a/qemu.robot
+++ b/qemu.robot
@@ -16,6 +16,7 @@ Preparing test environment
   Set Suite Variable    ${application_name}    %{application_name}
   Should Not Be Empty   ${application_name}    msg=application_name variable cannot be blank
   Set Suite Variable    ${device_type}    %{device_type}
+  Set Suite Variable    ${DNS_SERVER}     %{DNS_SERVER}
   Set Suite Variable    ${RESINRC_RESIN_URL}    %{RESINRC_RESIN_URL}
   Set Suite Variable    ${RESINRC_PROXY_URL}    %{RESINRC_PROXY_URL}
   Set Suite Variable    ${image}    %{image}

--- a/raspberrypi3.robot
+++ b/raspberrypi3.robot
@@ -13,6 +13,7 @@ Preparing test environment
   Set Suite Variable    ${proxy_ssh_port}    %{proxy_ssh_port}
   Set Suite Variable    ${application_name}    %{application_name}
   Set Suite Variable    ${device_type}    %{device_type}
+  Set Suite Variable    ${DNS_SERVER}   %{DNS_SERVER}
   Set Suite Variable    ${RESINRC_RESIN_URL}    %{RESINRC_RESIN_URL}
   Set Suite Variable    ${RESINRC_PROXY_URL}    %{RESINRC_PROXY_URL}
   Set Suite Variable    ${image}    %{image}

--- a/resources/resincli.robot
+++ b/resources/resincli.robot
@@ -67,6 +67,8 @@ Configure "${image}" version "${os_version}" with "${application_name}"
     Process ${result_register}
     ${result} =  Run Process    balena os configure ${image} --device ${result_register.stdout} --version ${os_version} --config-network ethernet --dev    shell=yes
     Process ${result}
+    ${result_dns} =  Run Process    test -n "${DNS_SERVER}" && balena config write --drive "${image}" dnsServers "${DNS_SERVER}"   shell=yes
+    Process ${result_dns}
     Return From Keyword    ${result_register.stdout}
 
 Get "${device_info}" of device "${device_uuid}"


### PR DESCRIPTION
This change allows users to set a custom DNS server in the config.json of the test device. The
DNS server is only set if the environment variable DNS_SERVER is set to a non-zero value.

This is needed to test with a balenaCloud instance whose address can only be resolved using a custom
name server. This is a common setup for balenaMachine deployments in air-gapped networks.

Change-type: patch