### PR TITLE
Fix to make the DNS_SERVER env var optional.

### DIFF
--- a/qemu.robot
+++ b/qemu.robot
@@ -16,7 +16,6 @@ Preparing test environment
   Set Suite Variable    ${application_name}    %{application_name}
   Should Not Be Empty   ${application_name}    msg=application_name variable cannot be blank
   Set Suite Variable    ${device_type}    %{device_type}
-  Set Suite Variable    ${DNS_SERVER}     %{DNS_SERVER}
   Set Suite Variable    ${RESINRC_RESIN_URL}    %{RESINRC_RESIN_URL}
   Set Suite Variable    ${RESINRC_PROXY_URL}    %{RESINRC_PROXY_URL}
   Set Suite Variable    ${image}    %{image}

--- a/raspberrypi3.robot
+++ b/raspberrypi3.robot
@@ -13,7 +13,6 @@ Preparing test environment
   Set Suite Variable    ${proxy_ssh_port}    %{proxy_ssh_port}
   Set Suite Variable    ${application_name}    %{application_name}
   Set Suite Variable    ${device_type}    %{device_type}
-  Set Suite Variable    ${DNS_SERVER}   %{DNS_SERVER}
   Set Suite Variable    ${RESINRC_RESIN_URL}    %{RESINRC_RESIN_URL}
   Set Suite Variable    ${RESINRC_PROXY_URL}    %{RESINRC_PROXY_URL}
   Set Suite Variable    ${image}    %{image}

--- a/resources/resincli.robot
+++ b/resources/resincli.robot
@@ -67,7 +67,8 @@ Configure "${image}" version "${os_version}" with "${application_name}"
     Process ${result_register}
     ${result} =  Run Process    balena os configure ${image} --device ${result_register.stdout} --version ${os_version} --config-network ethernet --dev    shell=yes
     Process ${result}
-    ${result_dns} =  Run Process    test -n "${DNS_SERVER}" && balena config write --drive "${image}" dnsServers "${DNS_SERVER}"   shell=yes
+    ${DNS_SERVER} =   Get Environment Variable    DNS_SERVER    default=True
+    ${result_dns} =   Run Keyword If    '${DNS_SERVER}' != ''    Run Process    balena config write --drive "${image}" dnsServers "${DNS_SERVER}"   shell=yes
     Process ${result_dns}
     Return From Keyword    ${result_register.stdout}
 


### PR DESCRIPTION
This fix allows the script to run even if the variable is not defined in the environment.

Change-type: patch