### PR TITLE
Allow any self-hosted runner of matching arch

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -25,8 +25,7 @@ jobs:
         ghcr.io/balena-io/autohat
       docker_runs_on: >
         {
-
-          "linux/amd64": ["self-hosted","distro:jammy","platform:linux/amd64"],
-          "linux/arm64": ["self-hosted","distro:jammy","platform:linux/arm64"]
+          "linux/amd64": ["self-hosted","X64"],
+          "linux/arm64": ["self-hosted","ARM64"]
         }
 


### PR DESCRIPTION
For most Docker builds the host OS variant doesn't matter.

Change-type: patch