### PR TITLE
Improve QEMU TCG performance and add serial log collection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     binutils \
     curl \
     fdisk \
+    expect \
     git \
     jq \
     libfdt1 \
@@ -64,6 +65,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     qemu-system-x86=${QEMU_VERSION} \
     qemu-utils=${QEMU_VERSION} \
     rsync \
+    socat \
     systemd \
     zlib1g \
     && rm -rf /var/lib/apt/lists/*

--- a/resources/collect-journal.sh
+++ b/resources/collect-journal.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sock="${1:?usage: $0 /path/to/console.sock username [outfile]}"
+user="${2:?usage: $0 /path/to/console.sock username [outfile]}"
+outfile="${3:-journalctl-$(date +%Y%m%d-%H%M%S).log}"
+
+raw_log=$(mktemp "${outfile}.raw.XXXXXX")
+trap 'rm -f "$raw_log"' EXIT
+
+marker="$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n')"
+begin_marker="__JOURNAL_BEGIN_${marker}__"
+end_marker="__JOURNAL_END_${marker}__"
+
+expect -f - "$sock" "$user" "$raw_log" "$begin_marker" "$end_marker" <<'EXPECT_SCRIPT'
+set timeout 120
+set sock         [lindex $argv 0]
+set user         [lindex $argv 1]
+set rawlog       [lindex $argv 2]
+set begin_marker [lindex $argv 3]
+set end_marker   [lindex $argv 4]
+
+set prompt_re {(?m)^[^\r\n]*[#$] ?$}
+set rc 0
+log_user 0
+
+spawn socat -,rawer,echo=0,escape=0x1d "unix-connect:$sock"
+
+# --- login ---
+send -- "\r"
+
+set need_login 1
+expect {
+  -re {(?i)login:\s*$} {}
+  -re $prompt_re {
+    set need_login 0
+  }
+  timeout { send_user "timed out waiting for login prompt\n"; exit 1 }
+  eof     { send_user "console closed before login\n"; exit 1 }
+}
+
+if {$need_login} {
+  send -- "$user\r"
+
+  expect {
+    -re $prompt_re {}
+    timeout { send_user "timed out waiting for shell prompt after login\n"; exit 1 }
+    eof     { send_user "console closed after login\n"; exit 1 }
+  }
+}
+
+# --- sanity check ---
+send -- "hostname; printf '__HOST_DONE__\\n'\r"
+expect {
+  -re {([^\r\n]+)\r?\n__HOST_DONE__} {
+    send_user "logged in to: $expect_out(1,string)\n"
+  }
+  timeout { send_user "timed out waiting for hostname output\n"; exit 1 }
+  eof     { send_user "console closed during sanity check\n"; exit 1 }
+}
+
+# --- collect journal ---
+log_file -noappend $rawlog
+
+send -- "printf '%s\\n' '$begin_marker'; journalctl -b --no-pager --output=short-iso; rc=\$?; printf '\\n%s rc=%s\\n' '$end_marker' \"\$rc\"\r"
+
+expect {
+  -re "${end_marker} rc=([0-9]+)" {
+    set rc $expect_out(1,string)
+  }
+  timeout { send_user "timed out waiting for journalctl output\n"; exit 1 }
+  eof     { send_user "console closed while collecting logs\n"; exit 1 }
+}
+
+log_file
+
+# --- close transport cleanly ---
+send -- "exit\r"
+expect {
+  -re {(?i)login:\s*$} {}
+  timeout {}
+}
+close
+wait
+
+if {$rc ne "0"} {
+  send_user "journalctl exited with rc=$rc\n"
+  exit $rc
+}
+
+exit 0
+EXPECT_SCRIPT
+
+tr -d '\r' <"$raw_log" |
+  awk -v b="$begin_marker" -v e="$end_marker" '
+      index($0, b) { in_block=1; next }
+      index($0, e) { in_block=0; exit }
+      in_block { print }
+    ' \
+    >"$outfile"
+
+echo "wrote $outfile"

--- a/resources/qemu.resource
+++ b/resources/qemu.resource
@@ -52,14 +52,14 @@ Run aarch64 image
 Run "gpt" image with "${acceleration}" acceleration
     # qemu-system-x86_64 defunct process without shell
     ${handle} =    Start Process
-    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image_copy},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=q35 -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off -serial chardev:serial0 -bios /usr/share/ovmf/OVMF.fd -nodefaults
+    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image_copy},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device virtio-blk-pci,drive\=disk -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -device virtio-rng-pci -m ${memory} -nographic -machine type\=q35 -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off -serial chardev:serial0 -bios /usr/share/ovmf/OVMF.fd -nodefaults -D /tmp/qemu.log -d guest_errors,cpu_reset
     ...    shell=yes
     RETURN    ${handle}
 
 Run "dos" image with "${acceleration}" acceleration
     # qemu-system-x86_64 defunct process without shell
     ${handle} =    Start Process
-    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image_copy},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off -serial chardev:serial0
+    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image_copy},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off -serial chardev:serial0 -D /tmp/qemu.log -d guest_errors,cpu_reset
     ...    shell=yes
     RETURN    ${handle}
 
@@ -69,6 +69,22 @@ Run "aarch64" image with "${acceleration}" acceleration
     ${result} =    Run Buffered Process    qemu-img resize ${image_copy} 4G    shell=yes
     Process ${result}
     ${handle} =    Start Process
-    ...    qemu-system-aarch64 -drive file\=${image_copy},media\=disk,cache\=none,format\=raw -device virtio-net-device,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=virt -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off -serial chardev:serial0 -cpu cortex-a72 -bios /usr/share/AAVMF/AAVMF_CODE.fd -nodefaults
+    ...    qemu-system-aarch64 -drive file\=${image_copy},media\=disk,cache\=none,format\=raw -device virtio-net-device,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -device virtio-rng-device -m ${memory} -nographic -machine type\=virt -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off -serial chardev:serial0 -cpu cortex-a72 -bios /usr/share/AAVMF/AAVMF_CODE.fd -nodefaults -D /tmp/qemu.log -d guest_errors,cpu_reset
     ...    shell=yes
     RETURN    ${handle}
+
+Stream serial console "${serial_port_path}" to "${log_path}"
+    ${cmd} =    Set Variable    socat -u UNIX-CONNECT:${serial_port_path},retry=20,interval=1 OPEN:${log_path},creat
+    ${handle} =    Start Process    ${cmd}    shell=yes
+    RETURN    ${handle}
+
+Collect QEMU Serial Logs with "${serial_port_path}" to "${log_path}"
+    [Documentation]    Retrieve journal logs from the QEMU VM via the serial console
+    ...    socket using expect/socat and save them to the given log path.
+    ${result} =    Run Process
+    ...    ${CURDIR}/collect-journal.sh    ${serial_port_path}    root    ${log_path}
+    ...    timeout=180s
+    Log    stdout: ${result.stdout}
+    Log    stderr: ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0
+    ...    msg=Failed to collect journal logs: ${result.stderr}


### PR DESCRIPTION
- Force 1 vCPU for TCG to avoid atomic instruction contention
- Add expect/socat script to collect journal logs over serial socket
- Add virtio-rng device to improve guest entropy during boot
- Enable QEMU debug logging (guest_errors, cpu_reset)

Change-type: minor