### PR TITLE
qemu: update to 1:10.0.8+ds-0+deb13u1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:/usr/local/bin:${PATH}"
 # https://repology.org/project/qemu/versions
 # https://packages.debian.org/trixie/source/qemu
 # renovate: datasource=repology depName=debian_13/qemu-utils versioning=loose
-ARG QEMU_VERSION=1:10.0.7+ds-0+deb13u1+b1
+ARG QEMU_VERSION=1:10.0.8+ds-0+deb13u1+b1
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Includes upstream stable bug fixes and security fixes for CVE-2025-14876 and CVE-2026-0665.

Complete changelog here:
https://metadata.ftp-master.debian.org/changelogs//main/q/qemu/qemu_10.0.8+ds-0+deb13u1_changelog

Change-type: patch