### PR TITLE
patch: Move logs extraction to autohat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,6 @@ ENV PATH="/opt/balena-cli/bin:${PATH}"
 
 COPY --from=python-build /opt/venv /opt/venv
 
-COPY *.robot /opt/
-
 COPY resources/* /opt/resources/
 
 COPY fixtures/ssh_config /root/.ssh/config
@@ -84,6 +82,8 @@ RUN chmod 400 /root/.ssh/*
 COPY udev_rules/autohat.rules /etc/udev/rules.d/
 
 COPY services/dev2.mount /etc/systemd/system/
+
+COPY scripts/extract_persistent_logs.sh /usr/local/bin/
 
 RUN systemctl enable dev2.mount
 

--- a/resources/qemu.resource
+++ b/resources/qemu.resource
@@ -47,14 +47,14 @@ Run aarch64 image
 Run "gpt" image with "${acceleration}" acceleration
     # qemu-system-x86_64 defunct process without shell
     ${handle} =    Start Process
-    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=q35 -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=/tmp/logs/serial.log -serial chardev:serial0 -bios /usr/share/ovmf/OVMF.fd -nodefaults
+    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=q35 -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0 -bios /usr/share/ovmf/OVMF.fd -nodefaults
     ...    shell=yes
     RETURN    ${handle}
 
 Run "dos" image with "${acceleration}" acceleration
     # qemu-system-x86_64 defunct process without shell
     ${handle} =    Start Process
-    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=/tmp/logs/serial.log -serial chardev:serial0
+    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0
     ...    shell=yes
     RETURN    ${handle}
 
@@ -64,6 +64,14 @@ Run "aarch64" image with "${acceleration}" acceleration
     ${result} =    Run Buffered Process    qemu-img resize ${image} 4G    shell=yes
     Process ${result}
     ${handle} =    Start Process
-    ...    qemu-system-aarch64 -drive file\=${image},media\=disk,cache\=none,format\=raw -device virtio-net-device,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=virt -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=/tmp/logs/serial.log -serial chardev:serial0 -cpu cortex-a72 -bios /usr/share/AAVMF/AAVMF_CODE.fd -nodefaults
+    ...    qemu-system-aarch64 -drive file\=${image},media\=disk,cache\=none,format\=raw -device virtio-net-device,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=virt -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0 -cpu cortex-a72 -bios /usr/share/AAVMF/AAVMF_CODE.fd -nodefaults
     ...    shell=yes
     RETURN    ${handle}
+
+Extract Journald Runtime Logs From "${image}" to "${output}"
+    [Documentation]    Mount the image to get the logs from runtime.
+    ${result} =    Run Process
+    ...    extract_persistent_logs.sh "${output}" "${image}"
+    ...    shell=yes
+    ...    stderr=STDOUT
+    Log    ${result.stdout}

--- a/resources/qemu.resource
+++ b/resources/qemu.resource
@@ -47,14 +47,14 @@ Run aarch64 image
 Run "gpt" image with "${acceleration}" acceleration
     # qemu-system-x86_64 defunct process without shell
     ${handle} =    Start Process
-    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=q35 -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=/tmp/logs/serial.log -serial chardev:serial0 -bios /usr/share/ovmf/OVMF.fd -nodefaults
+    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=q35 -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0 -bios /usr/share/ovmf/OVMF.fd -nodefaults
     ...    shell=yes
     RETURN    ${handle}
 
 Run "dos" image with "${acceleration}" acceleration
     # qemu-system-x86_64 defunct process without shell
     ${handle} =    Start Process
-    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=/tmp/logs/serial.log -serial chardev:serial0
+    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0
     ...    shell=yes
     RETURN    ${handle}
 
@@ -64,6 +64,17 @@ Run "aarch64" image with "${acceleration}" acceleration
     ${result} =    Run Buffered Process    qemu-img resize ${image} 4G    shell=yes
     Process ${result}
     ${handle} =    Start Process
-    ...    qemu-system-aarch64 -drive file\=${image},media\=disk,cache\=none,format\=raw -device virtio-net-device,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=virt -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=/tmp/logs/serial.log -serial chardev:serial0 -cpu cortex-a72 -bios /usr/share/AAVMF/AAVMF_CODE.fd -nodefaults
+    ...    qemu-system-aarch64 -drive file\=${image},media\=disk,cache\=none,format\=raw -device virtio-net-device,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=virt -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0 -cpu cortex-a72 -bios /usr/share/AAVMF/AAVMF_CODE.fd -nodefaults
     ...    shell=yes
     RETURN    ${handle}
+
+Extract Journald Runtime Logs From "${image}" to "${output}"
+    [Documentation]    Mount the image to get the logs from runtime.
+    ${result} =    Run Process
+    ...    extract_persistent_logs.sh "${output}" "${image}"
+    ...    shell=yes
+    ...    stderr=STDOUT
+    Log    ${result.stdout}
+    IF    ${result.rc} != 0
+        Log    Log extraction failed (rc=${result.rc}): ${result.stdout}    WARN
+    END

--- a/scripts/extract_persistent_logs.sh
+++ b/scripts/extract_persistent_logs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+function cleanup() {
+  rm -rf "${tmpfdisk}" "${tmpmnt}"
+}
+trap cleanup EXIT
+
+tmpfdisk="$(mktemp)"
+fdisk -lu "${2}" >"${tmpfdisk}"
+cat <"${tmpfdisk}"
+
+uname -a
+tmpmnt="$(mktemp -d)"
+
+grep -E '(EFI|FAT16)' "${tmpfdisk}" | sed 's/*//g' | awk '{print $2}' |
+  while IFS= read -r offset; do
+    # look for installer migration log in FAT parts.
+    mntopts="ro,loop,offset=$((offset * 512))"
+    mount -o "${mntopts}" "${2}" "${tmpmnt}" || continue
+
+    # inspect FAT parts.
+    find "${tmpmnt}" -type f
+
+    # find balena image flasher (installer) initramfs mode log (should be in the boot part.)
+    # balena-os/meta-balena: docs/initramfs.md?plain=1#L24
+    # ..                     meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher#L561
+    find "${tmpmnt}" -type f -name 'migration_*' -print0 |
+      xargs -0r cat >"${1}/${offset}-flasher.log"
+    test -s "${1}/${offset}-flasher.log" || rm "${1}/${offset}-flasher.log"
+
+    umount "${tmpmnt}"
+  done
+
+grep Linux "${tmpfdisk}" | awk '{print $2}' |
+  while IFS= read -r offset; do
+    # look for system.journal in Linux parts.
+    for mntopt in ro ro,norecovery ro,rescue=nologreplay; do
+      # https://btrfs.readthedocs.io/en/latest/Kernel-by-version.html#jul-2024
+      mntopts="${mntopt},loop,offset=$((offset * 512))"
+      mount -o "${mntopts}" "${2}" "${tmpmnt}" && break # if mntopts accepted
+    done
+    # shellcheck disable=SC2181
+    [[ $? -eq 0 ]] || continue # continue to trying the next part.
+
+    # find systemd-journald logs
+    find "${tmpmnt}" -type f -name system.journal -print0 |
+      xargs -0r journalctl --no-pager --file >"${1}/${offset}-system.log"
+    test -s "${1}/${offset}-system.log" || rm "${1}/${offset}-system.log"
+
+    umount "${tmpmnt}"
+  done
+
+find "${1}" -type f

--- a/scripts/extract_persistent_logs.sh
+++ b/scripts/extract_persistent_logs.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+function cleanup() {
+  umount "${tmpmnt:-}" || true
+  rm -rf "${tmpfdisk:-}" "${tmpmnt:-}"
+}
+trap cleanup EXIT
+
+output_dir="${1:?usage: $0 <output_dir> <image>}"
+image="${2:?usage: $0 <output_dir> <image>}"
+[[ -d ${output_dir} ]] || {
+  echo "output dir not found: ${output_dir}" >&2
+  exit 64
+}
+[[ -r ${image} ]] || {
+  echo "image not readable: ${image}" >&2
+  exit 64
+}
+
+tmpfdisk="$(mktemp)"
+fdisk -lu "${image}" >"${tmpfdisk}"
+cat <"${tmpfdisk}"
+
+uname -a
+tmpmnt="$(mktemp -d)"
+extracted=0
+
+while IFS= read -r offset; do
+  # look for installer migration log in FAT parts.
+  mntopts="ro,loop,offset=$((offset * 512))"
+  mount -o "${mntopts}" "${image}" "${tmpmnt}" || continue
+
+  # inspect FAT parts.
+  find "${tmpmnt}" -type f
+
+  # find balena image flasher (installer) initramfs mode log (should be in the boot part.)
+  # balena-os/meta-balena: docs/initramfs.md?plain=1#L24
+  # ..                     meta-balena-common/recipes-support/resin-init/resin-init-flasher/resin-init-flasher#L561
+  find "${tmpmnt}" -type f -name 'migration_*' -print0 |
+    xargs -0r cat >"${output_dir}/${offset}-flasher.log"
+
+  if test -s "${output_dir}/${offset}-flasher.log"; then
+    extracted=$((extracted + 1))
+  else
+    rm -f "${output_dir}/${offset}-flasher.log"
+  fi
+
+  umount "${tmpmnt}"
+done < <(grep -E '(EFI|FAT16)' "${tmpfdisk}" | sed 's/*//g' | awk '{print $2}')
+
+while IFS= read -r offset; do
+  # look for system.journal in Linux parts.
+  mounted=0
+  for mntopt in ro ro,norecovery ro,rescue=nologreplay; do
+    # https://btrfs.readthedocs.io/en/latest/Kernel-by-version.html#jul-2024
+    mntopts="${mntopt},loop,offset=$((offset * 512))"
+    mount -o "${mntopts}" "${image}" "${tmpmnt}" && {
+      mounted=1
+      break
+    }
+  done
+  ((mounted)) || continue
+
+  # find all systemd-journald logs
+  journal_args=()
+  while IFS= read -r -d '' j; do
+    journal_args+=(--file "$j")
+  done < <(find "${tmpmnt}" -type f -name system.journal -print0)
+  ((${#journal_args[@]} > 0)) &&
+    journalctl --no-pager "${journal_args[@]}" >"${output_dir}/${offset}-system.log"
+
+  if test -s "${output_dir}/${offset}-system.log"; then
+    extracted=$((extracted + 1))
+  else
+    rm -f "${output_dir}/${offset}-system.log"
+  fi
+
+  umount "${tmpmnt}"
+done < <(grep -E 'Linux( filesystem)?$' "${tmpfdisk}" | awk '{print $2}')
+
+if ((extracted == 0)); then
+  echo "ERROR: no logs extracted from ${image}" >&2
+  exit 2
+else
+  find "${output_dir}" -type f
+fi


### PR DESCRIPTION
Use fdisk and journalctl already available in the autohat image to extract runtime journald logs from DUT after it has completed. Also try to fetch flasher/installer migration log from the boot partition.

Enables:
* https://github.com/balena-io/e2e/pull/1714
* (https://github.com/balena-io/balena-cloud/pull/6118)

https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/elevated-e2e-errors-200