### PR TITLE
Pin QEMU CPU model to Nehalem for x86_64 guests

### DIFF
--- a/resources/qemu.resource
+++ b/resources/qemu.resource
@@ -47,14 +47,14 @@ Run aarch64 image
 Run "gpt" image with "${acceleration}" acceleration
     # qemu-system-x86_64 defunct process without shell
     ${handle} =    Start Process
-    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=q35 -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0 -bios /usr/share/ovmf/OVMF.fd -nodefaults
+    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=q35 -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0 -cpu Nehalem -bios /usr/share/ovmf/OVMF.fd -nodefaults
     ...    shell=yes
     RETURN    ${handle}
 
 Run "dos" image with "${acceleration}" acceleration
     # qemu-system-x86_64 defunct process without shell
     ${handle} =    Start Process
-    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0
+    ...    qemu-system-x86_64 -device ahci,id\=ahci -drive file\=${image},media\=disk,cache\=none,format\=raw,if\=none,id\=disk -device ide-hd,drive\=disk,bus\=ahci.0 -device virtio-net-pci,netdev\=n1 -netdev \"user,id\=n1,dns\=127.0.0.1,guestfwd\=tcp:10.0.2.100:80-cmd:netcat haproxy 80,guestfwd\=tcp:10.0.2.100:443-cmd:netcat haproxy 443\" -m ${memory} -nographic -machine type\=pc -accel ${acceleration} -smp ${cpus} -chardev socket,id\=serial0,path\=${serial_port_path},server\=on,wait\=off,logfile\=${OUTPUT DIR}/serial.log -serial chardev:serial0 -cpu Nehalem
     ...    shell=yes
     RETURN    ${handle}
 


### PR DESCRIPTION
Without an explicit `-cpu`, `qemu-system-x86_64` defaults to `qemu64` under TCG, which omits SSSE3/SSE4. 

Scarthgap's toolchain now emits those instructions, causing `trap invalid opcode` SIGILLs in udevd and random userspace binaries during boot.

Pinning `-cpu Nehalem` restores a workable baseline; the aarch64 path already pins `cortex-a72`.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/elevated-e2e-errors-200